### PR TITLE
Removes unneeded fastFloor calls in 4D

### DIFF
--- a/csharp/OpenSimplex2S.cs
+++ b/csharp/OpenSimplex2S.cs
@@ -307,10 +307,10 @@ namespace Noise
             double ssi = (xsi + ysi + zsi + wsi) * -0.138196601125011;
             double xi = xsi + ssi, yi = ysi + ssi, zi = zsi + ssi, wi = wsi + ssi;
 
-            int index = ((fastFloor(xs * 4) & 3) << 0)
-                | ((fastFloor(ys * 4) & 3) << 2)
-                | ((fastFloor(zs * 4) & 3) << 4)
-                | ((fastFloor(ws * 4) & 3) << 6);
+            int index = (((xsb * 4) & 3) << 0)
+                | (((ysb * 4) & 3) << 2)
+                | (((zsb * 4) & 3) << 4)
+                | (((wsb * 4) & 3) << 6);
 
             // Point contributions
             foreach (LatticePoint4D c in LOOKUP_4D[index])

--- a/java/OpenSimplex2S.java
+++ b/java/OpenSimplex2S.java
@@ -282,12 +282,12 @@ public class OpenSimplex2S {
 		// Unskewed offsets
 		double ssi = (xsi + ysi + zsi + wsi) * -0.138196601125011;
 		double xi = xsi + ssi, yi = ysi + ssi, zi = zsi + ssi, wi = wsi + ssi;
-			
-		int index = ((fastFloor(xs * 4) & 3) << 0)
-			| ((fastFloor(ys * 4) & 3) << 2)
-			| ((fastFloor(zs * 4) & 3) << 4)
-			| ((fastFloor(ws * 4) & 3) << 6);
-		
+
+		int index = (((xsb * 4) & 3) << 0)
+			| (((ysb * 4) & 3) << 2)
+			| (((zsb * 4) & 3) << 4)
+			| (((wsb * 4) & 3) << 6);
+
 		// Point contributions
 		for (LatticePoint4D c : LOOKUP_4D[index]) {
 			double dx = xi + c.dx, dy = yi + c.dy, dz = zi + c.dz, dw = wi + c.dw;


### PR DESCRIPTION
Hello I was busy porting opensimplex2S to python and noticed this small optimization. Doesn't seem to affect the output I think (I only verified the C# version)

Edit: Eeh just noticed you've already started with a new optimized version at your [Noise-Extras](https://github.com/KdotJPG/Noise-Extras/blob/master/alternative_implementations/OpenSimplex2F_Shorter4DCode.java) repo that doesn't have this block anymore