### PR TITLE
Improve rust version performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ lto = "fat"
 codegen-units = 1
 panic = "abort"
 
+[features]
+default = []
+std = []
+
 [lints]
 clippy.excessive_precision = "allow"
 clippy.identity_op = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "opensimplex2"
 version = "1.1.0"
 edition = "2021"
+rust-version = "1.70.0"
 
 description = "Port of OpenSimplex2"
 authors = ["KdotJPG"]
@@ -19,3 +20,17 @@ include = [
 [lib]
 path = "rust/lib.rs"
 crate-type = ["rlib", "staticlib", "cdylib"]
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+
+[lints]
+clippy.excessive_precision = "allow"
+clippy.identity_op = "allow"
+clippy.too_many_arguments = "allow"
+clippy.approx_constant = "allow"
+clippy.suboptimal_flops = "allow"
+

--- a/examples/seed_2d.rs
+++ b/examples/seed_2d.rs
@@ -7,15 +7,16 @@ fn main() {
 
     for _ in 0..10 {
         let iteration_time = Instant::now();
+        let mut res = 0.0; // To not optimize away the loop
 
         for x in 0..8000 {
             for y in 0..8000 {
-                let _ = opensimplex2::fast::noise2(SEED, x as f64, y as f64);
+                res += opensimplex2::fast::noise2(SEED, x as f64, y as f64);
             }
         }
 
         println!(
-            "Rust Impl 2D: {} msec",
+            "Rust Impl 2D: {} msec (Res: {res})",
             iteration_time.elapsed().as_millis()
         );
     }

--- a/examples/seed_2d.rs
+++ b/examples/seed_2d.rs
@@ -1,0 +1,22 @@
+use std::time::Instant;
+
+fn main() {
+    const SEED: i64 = 0;
+
+    let _ = opensimplex2::fast::noise2(SEED, 0.0, 0.0);
+
+    for _ in 0..10 {
+        let iteration_time = Instant::now();
+
+        for x in 0..8000 {
+            for y in 0..8000 {
+                let _ = opensimplex2::fast::noise2(SEED, x as f64, y as f64);
+            }
+        }
+
+        println!(
+            "Rust Impl 2D: {} msec",
+            iteration_time.elapsed().as_millis()
+        );
+    }
+}

--- a/rust/fast.rs
+++ b/rust/fast.rs
@@ -595,8 +595,6 @@ fn initGradients() -> Gradients {
     let gradients2D: Vec<_> = GRAD2_SRC
         .iter()
         .map(|v| (v / NORMALIZER_2D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_2D * 2) as usize)
         .collect();
@@ -604,8 +602,6 @@ fn initGradients() -> Gradients {
     let gradients3D: Vec<_> = GRAD3_SRC
         .iter()
         .map(|v| (v / NORMALIZER_3D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_3D * 4) as usize)
         .collect();
@@ -613,8 +609,6 @@ fn initGradients() -> Gradients {
     let gradients4D: Vec<_> = GRAD4_SRC
         .iter()
         .map(|v| (v / NORMALIZER_4D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_4D * 4) as usize)
         .collect();

--- a/rust/ffi.rs
+++ b/rust/ffi.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_double, c_float, c_longlong};
+use core::ffi::{c_double, c_float, c_longlong};
 
 use crate::{fast, smooth};
 

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(non_snake_case)]
 
 pub mod fast;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![allow(non_snake_case)]
 
 pub mod fast;

--- a/rust/smooth.rs
+++ b/rust/smooth.rs
@@ -834,8 +834,6 @@ fn initStaticData() -> StaticData {
     let gradients2D: Vec<_> = GRAD2_SRC
         .iter()
         .map(|v| (v / NORMALIZER_2D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_2D * 2) as usize)
         .collect();
@@ -843,8 +841,6 @@ fn initStaticData() -> StaticData {
     let gradients3D: Vec<_> = GRAD3_SRC
         .iter()
         .map(|v| (v / NORMALIZER_3D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_3D * 4) as usize)
         .collect();
@@ -852,8 +848,6 @@ fn initStaticData() -> StaticData {
     let gradients4D: Vec<_> = GRAD4_SRC
         .iter()
         .map(|v| (v / NORMALIZER_4D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_4D * 4) as usize)
         .collect();


### PR DESCRIPTION
The main issue was that instead of using OnceLock (which was stabilized about half a year after the initial version was merged), a custom implementation was used.
That implementation relied on unwrap in a critical section, which significantly reduced performance.

Additionally, it caused the following warnings in Rust 1.91.0:
```
warning: creating a shared reference to mutable static
   --> rust/smooth.rs:831:9
    |
831 | /         STATIC_DATA.0.call_once(|| {
832 | |             STATIC_DATA.1 = Some(initStaticData());
833 | |         });
    | |__________^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: creating a shared reference to mutable static
   --> rust/smooth.rs:834:9
    |
834 |         STATIC_DATA.1.as_ref().unwrap()
    |         ^^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

warning: `opensimplex2` (lib) generated 4 warnings
```

I’ve also added simple stability tests to prevent accidental changes to the function output in the future.
An additional example was included to make it easier to verify performance.


Old implementation - ~640ms

![old](https://github.com/user-attachments/assets/f0a3aafb-44ff-40cb-98b4-e08bf73997dc)

New implementation - ~490ms

![new](https://github.com/user-attachments/assets/58609bdf-46fe-42f7-876e-d95035c6e137)
