### PR TITLE
CMake Inteface implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+Cargo.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,109 +1,40 @@
 cmake_minimum_required(VERSION 3.19)
 
-set(CURRENT_PROJECT "OpenSimplex2")
+set(CURRENT_PROJECT "OpenSimplex2Interface")
 
-option(OPENSIMPLEX_OLD "Enable build old C implementation instead Rust" OFF)
+option(OPENSIMPLEX_C "Enable build old C implementation instead Rust" OFF)
+option(OPENSIMPLEX_RUST "Enable build old C implementation instead Rust" ON)
 
-if (OPENSIMPLEX_OLD)
+
+add_library(${CURRENT_PROJECT} INTERFACE)
+
+if (OPENSIMPLEX_RUST)
+
+    include(FetchContent)
+
+    FetchContent_Declare(
+        Corrosion
+        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+        GIT_TAG v0.5
+    )
+    FetchContent_MakeAvailable(Corrosion)
+    corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml ALL_FEATURES)
+
+    target_link_libraries(${CURRENT_PROJECT} INTERFACE "opensimplex2")
+    target_include_directories(${CURRENT_PROJECT} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+endif()
+
+if (OPENSIMPLEX_C)
 
     set(SOURCE_CPP
         "${CMAKE_CURRENT_SOURCE_DIR}/_old/c/OpenSimplex2F.c"
         "${CMAKE_CURRENT_SOURCE_DIR}/_old/c/OpenSimplex2F.h"
     )
 
-    add_library(${CURRENT_PROJECT} ${SOURCE_CPP})
-    target_include_directories(${CURRENT_PROJECT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/_old/c/")
-    target_compile_options(${CURRENT_PROJECT} PRIVATE -Wall -Wextra --pedantic)
-
-else()
-    include(ExternalProject)
-
-    ExternalProject_Add(
-        ${CURRENT_PROJECT}Rust
-        DOWNLOAD_COMMAND ""
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND cargo build COMMAND cargo build --release --features std --target-dir "${CMAKE_CURRENT_BINARY_DIR}"
-        BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
-        INSTALL_COMMAND ""
-        LOG_BUILD ON)
-
-
-    # ADD_CUSTOM_TARGET(
-    #     ${CURRENT_PROJECT}Rust
-    #     COMMAND cargo build --release --features std --target-dir "${CMAKE_CURRENT_BINARY_DIR}"
-    #     COMMENT "cargo build --release --features std --target-dir ${CMAKE_CURRENT_BINARY_DIR}"
-    #     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    # )
-
-    if(WIN32)
-        if (BUILD_SHARED_LIBS)
-            add_library( ${CURRENT_PROJECT} SHARED IMPORTED )
-
-            # You can define two import-locations: one for debug and one for release.
-            set_target_properties( ${CURRENT_PROJECT}
-                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/lib${CURRENT_PROJECT}.dll
-                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
-                IMPORTED_IMPLIB ${CMAKE_CURRENT_BINARY_DIR}/release/lib${CURRENT_PROJECT}.lib
-            )
-        else()
-            add_library( ${CURRENT_PROJECT} STATIC IMPORTED )
-
-            # You can define two import-locations: one for debug and one for release.
-            set_target_properties( ${CURRENT_PROJECT}
-                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.lib
-                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
-
-            )
-        endif()
-
-    elseif(APPLE)
-
-        if (BUILD_SHARED_LIBS)
-            add_library( ${CURRENT_PROJECT} SHARED IMPORTED )
-
-            # You can define two import-locations: one for debug and one for release.
-            set_target_properties( ${CURRENT_PROJECT}
-                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.dylib
-                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
-
-            )
-        else()
-            add_library( ${CURRENT_PROJECT} STATIC IMPORTED )
-
-            # You can define two import-locations: one for debug and one for release.
-            set_target_properties( ${CURRENT_PROJECT}
-                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.lib
-                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
-
-            )
-        endif()
-
-    elseif(UNIX)
-        if (BUILD_SHARED_LIBS)
-            add_library( ${CURRENT_PROJECT} SHARED IMPORTED )
-
-            # You can define two import-locations: one for debug and one for release.
-            set_target_properties( ${CURRENT_PROJECT}
-                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.so
-                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
-                IMPORTED_SONAME "lib${CURRENT_PROJECT}.so"
-
-            )
-        else()
-            add_library( ${CURRENT_PROJECT} STATIC IMPORTED )
-
-            # You can define two import-locations: one for debug and one for release.
-            set_target_properties( ${CURRENT_PROJECT}
-                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.a
-                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
-                IMPORTED_SONAME "lib${CURRENT_PROJECT}.a"
-
-            )
-        endif()
-
-    endif()
-
-    add_dependencies(${CURRENT_PROJECT} ${CURRENT_PROJECT}Rust)
-
+    add_library(${CURRENT_PROJECT}C ${SOURCE_CPP})
+    target_include_directories(${CURRENT_PROJECT}C PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/_old/")
+    target_compile_options(${CURRENT_PROJECT}C PRIVATE -Wall -Wextra --pedantic)
+    target_link_libraries(${CURRENT_PROJECT} INTERFACE ${CURRENT_PROJECT}C)
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,109 @@
+cmake_minimum_required(VERSION 3.19)
+
+set(CURRENT_PROJECT "OpenSimplex2")
+
+option(OPENSIMPLEX_OLD "Enable build old C implementation instead Rust" OFF)
+
+if (OPENSIMPLEX_OLD)
+
+    set(SOURCE_CPP
+        "${CMAKE_CURRENT_SOURCE_DIR}/_old/c/OpenSimplex2F.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/_old/c/OpenSimplex2F.h"
+    )
+
+    add_library(${CURRENT_PROJECT} ${SOURCE_CPP})
+    target_include_directories(${CURRENT_PROJECT} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/_old/c/")
+    target_compile_options(${CURRENT_PROJECT} PRIVATE -Wall -Wextra --pedantic)
+
+else()
+    include(ExternalProject)
+
+    ExternalProject_Add(
+        ${CURRENT_PROJECT}Rust
+        DOWNLOAD_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND cargo build COMMAND cargo build --release --features std --target-dir "${CMAKE_CURRENT_BINARY_DIR}"
+        BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+        INSTALL_COMMAND ""
+        LOG_BUILD ON)
+
+
+    # ADD_CUSTOM_TARGET(
+    #     ${CURRENT_PROJECT}Rust
+    #     COMMAND cargo build --release --features std --target-dir "${CMAKE_CURRENT_BINARY_DIR}"
+    #     COMMENT "cargo build --release --features std --target-dir ${CMAKE_CURRENT_BINARY_DIR}"
+    #     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    # )
+
+    if(WIN32)
+        if (BUILD_SHARED_LIBS)
+            add_library( ${CURRENT_PROJECT} SHARED IMPORTED )
+
+            # You can define two import-locations: one for debug and one for release.
+            set_target_properties( ${CURRENT_PROJECT}
+                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/lib${CURRENT_PROJECT}.dll
+                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+                IMPORTED_IMPLIB ${CMAKE_CURRENT_BINARY_DIR}/release/lib${CURRENT_PROJECT}.lib
+            )
+        else()
+            add_library( ${CURRENT_PROJECT} STATIC IMPORTED )
+
+            # You can define two import-locations: one for debug and one for release.
+            set_target_properties( ${CURRENT_PROJECT}
+                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.lib
+                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+
+            )
+        endif()
+
+    elseif(APPLE)
+
+        if (BUILD_SHARED_LIBS)
+            add_library( ${CURRENT_PROJECT} SHARED IMPORTED )
+
+            # You can define two import-locations: one for debug and one for release.
+            set_target_properties( ${CURRENT_PROJECT}
+                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.dylib
+                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+
+            )
+        else()
+            add_library( ${CURRENT_PROJECT} STATIC IMPORTED )
+
+            # You can define two import-locations: one for debug and one for release.
+            set_target_properties( ${CURRENT_PROJECT}
+                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.lib
+                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+
+            )
+        endif()
+
+    elseif(UNIX)
+        if (BUILD_SHARED_LIBS)
+            add_library( ${CURRENT_PROJECT} SHARED IMPORTED )
+
+            # You can define two import-locations: one for debug and one for release.
+            set_target_properties( ${CURRENT_PROJECT}
+                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.so
+                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+                IMPORTED_SONAME "lib${CURRENT_PROJECT}.so"
+
+            )
+        else()
+            add_library( ${CURRENT_PROJECT} STATIC IMPORTED )
+
+            # You can define two import-locations: one for debug and one for release.
+            set_target_properties( ${CURRENT_PROJECT}
+                PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/libopensimplex.a
+                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+                IMPORTED_SONAME "lib${CURRENT_PROJECT}.a"
+
+            )
+        endif()
+
+    endif()
+
+    add_dependencies(${CURRENT_PROJECT} ${CURRENT_PROJECT}Rust)
+
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.19)
 
 set(CURRENT_PROJECT "OpenSimplex2Interface")
 
-option(OPENSIMPLEX_C "Enable build old C implementation instead Rust" OFF)
-option(OPENSIMPLEX_RUST "Enable build old C implementation instead Rust" ON)
+option(OPENSIMPLEX_C "Enable/Disable build of the old C implementation" OFF)
+option(OPENSIMPLEX_RUST "Enable/Disable build of the main Rust implementation" ON)
 
 
 add_library(${CURRENT_PROJECT} INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ if (OPENSIMPLEX_RUST)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5
+        GIT_TAG v0.5.2
+
     )
     FetchContent_MakeAvailable(Corrosion)
     corrosion_import_crate(MANIFEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml ALL_FEATURES)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ lto = "fat"
 codegen-units = 1
 panic = "abort"
 
+[features]
+default = []
+std = []
+
 [lints]
 clippy.excessive_precision = "allow"
 clippy.identity_op = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "opensimplex2"
 version = "1.1.0"
 edition = "2021"
+rust-version = "1.70.0"
 
 description = "Port of OpenSimplex2"
 authors = ["KdotJPG"]
@@ -19,3 +20,17 @@ include = [
 [lib]
 path = "rust/lib.rs"
 crate-type = ["rlib", "staticlib", "cdylib"]
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+
+[lints]
+clippy.excessive_precision = "allow"
+clippy.identity_op = "allow"
+clippy.too_many_arguments = "allow"
+clippy.approx_constant = "allow"
+clippy.suboptimal_flops = "allow"
+

--- a/README.md
+++ b/README.md
@@ -38,18 +38,55 @@ Gradient vector tables were also revisited to improve probability symmetry in bo
 Note: area-generators have been moved to [their original repository](https://github.com/KdotJPG/Noise-VertexQueue-AreaGen).
 
 ## C FFI usage
+
+### Monual usage
 Install a [Rust toolchain](https://www.rust-lang.org/tools/install) if needed.
 
 Build debug or release artifacts with:
 ```
 cargo build
 # or
-cargo build --release
+cargo build --release --features std
 ```
 Library files will be in `./target/{debug,release}/`. Copy header from [`./rust/OpenSimplex2.h`](./rust/OpenSimplex2.h).
 
+### CMake
+
+To include the library in your own CMake project, simply add the subdirectory and link the OpenSimplex2 interface target:
+
+```cmake
+add_subdirectory(submodules/OpenSimplex2)
+target_link_libraries(${CURRENT_PROJECT} PUBLIC OpenSimplex2Interface)
+```
+
+The OpenSimplex2 interface provides two implementation backends (C and Rust).
+By default, only the Rust backend is compiled.
+To control which backend should be used, configure the following options:
+
+* OPENSIMPLEX_C — OFF by default
+* OPENSIMPLEX_RUST — ON by default
+
+You can enable both backends simultaneously if needed.
+To override the default options, use:
+
+```cmake 
+option(OPENSIMPLEX_C "Enable build old C implementation instead Rust" ON)
+option(OPENSIMPLEX_RUST "Enable build old C implementation instead Rust" ON)
+```
+
+### Including in C/C++ Projects
+
+``` cpp
+#include <c/OpenSimplex2F.h> // if the OPENSIMPLEX_C option enabled
+#include <rust/OpenSimplex2.h> // if the OPENSIMPLEX_RUST option enabled
+```
+
+**Note:**
+The C and Rust implementations use different function names to call the noise generators.
+
 ## Changelog
 
+* Rust implementation optimisations and CMake Inteface implementation (Nov 12, 2025)
 * Tuned up this `README.md`. (Mar 26, 2022)
 * Re-wrote functions to be instancelessly seedable and less dependent on lookup tables. Re-organized repository. Renamed `OpenSimplex2F` to just `OpenSimplex2` in file/class names. (Jan 16, 2022)
 * Shortened lookup table for Simplex/OpenSimplex2(F) 4D (July 5, 2020)

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ You can enable both backends simultaneously if needed.
 To override the default options, use:
 
 ```cmake 
-option(OPENSIMPLEX_C "Enable build old C implementation instead Rust" ON)
-option(OPENSIMPLEX_RUST "Enable build old C implementation instead Rust" ON)
+option(OPENSIMPLEX_C "Enable/Disable build of the old C implementation" OFF)
+option(OPENSIMPLEX_RUST "Enable/Disable build of the main Rust implementation" ON)
 ```
 
 ### Including in C/C++ Projects

--- a/examples/seed_2d.rs
+++ b/examples/seed_2d.rs
@@ -7,15 +7,16 @@ fn main() {
 
     for _ in 0..10 {
         let iteration_time = Instant::now();
+        let mut res = 0.0; // To not optimize away the loop
 
         for x in 0..8000 {
             for y in 0..8000 {
-                let _ = opensimplex2::fast::noise2(SEED, x as f64, y as f64);
+                res += opensimplex2::fast::noise2(SEED, x as f64, y as f64);
             }
         }
 
         println!(
-            "Rust Impl 2D: {} msec",
+            "Rust Impl 2D: {} msec (Res: {res})",
             iteration_time.elapsed().as_millis()
         );
     }

--- a/examples/seed_2d.rs
+++ b/examples/seed_2d.rs
@@ -1,0 +1,22 @@
+use std::time::Instant;
+
+fn main() {
+    const SEED: i64 = 0;
+
+    let _ = opensimplex2::fast::noise2(SEED, 0.0, 0.0);
+
+    for _ in 0..10 {
+        let iteration_time = Instant::now();
+
+        for x in 0..8000 {
+            for y in 0..8000 {
+                let _ = opensimplex2::fast::noise2(SEED, x as f64, y as f64);
+            }
+        }
+
+        println!(
+            "Rust Impl 2D: {} msec",
+            iteration_time.elapsed().as_millis()
+        );
+    }
+}

--- a/rust/OpenSimplex2.h
+++ b/rust/OpenSimplex2.h
@@ -1,5 +1,9 @@
-#pragma once
 #ifndef OPENSIMPLEX2_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 extern float opensimplex2_fast_noise2(long long seed, double x, double y);
 extern float opensimplex2_fast_noise2_ImproveX(long long seed, double x, double y);
@@ -21,5 +25,9 @@ extern float opensimplex2_smooth_noise4_ImproveXYZ_ImproveXZ(long long seed, dou
 extern float opensimplex2_smooth_noise4_ImproveXYZ(long long seed, double x, double y, double z, double w);
 extern float opensimplex2_smooth_noise4_ImproveXY_ImproveZW(long long seed, double x, double y, double z, double w);
 extern float opensimplex2_smooth_noise4_Fallback(long long seed, double x, double y, double z, double w);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/rust/OpenSimplex2.h
+++ b/rust/OpenSimplex2.h
@@ -1,5 +1,5 @@
 #ifndef OPENSIMPLEX2_H
-
+#define OPENSIMPLEX2_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/rust/fast.rs
+++ b/rust/fast.rs
@@ -595,8 +595,6 @@ fn initGradients() -> Gradients {
     let gradients2D: Vec<_> = GRAD2_SRC
         .iter()
         .map(|v| (v / NORMALIZER_2D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_2D * 2) as usize)
         .collect();
@@ -604,8 +602,6 @@ fn initGradients() -> Gradients {
     let gradients3D: Vec<_> = GRAD3_SRC
         .iter()
         .map(|v| (v / NORMALIZER_3D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_3D * 4) as usize)
         .collect();
@@ -613,8 +609,6 @@ fn initGradients() -> Gradients {
     let gradients4D: Vec<_> = GRAD4_SRC
         .iter()
         .map(|v| (v / NORMALIZER_4D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_4D * 4) as usize)
         .collect();

--- a/rust/ffi.rs
+++ b/rust/ffi.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_double, c_float, c_longlong};
+use core::ffi::{c_double, c_float, c_longlong};
 
 use crate::{fast, smooth};
 

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(non_snake_case)]
 
 pub mod fast;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![allow(non_snake_case)]
 
 pub mod fast;

--- a/rust/smooth.rs
+++ b/rust/smooth.rs
@@ -834,8 +834,6 @@ fn initStaticData() -> StaticData {
     let gradients2D: Vec<_> = GRAD2_SRC
         .iter()
         .map(|v| (v / NORMALIZER_2D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_2D * 2) as usize)
         .collect();
@@ -843,8 +841,6 @@ fn initStaticData() -> StaticData {
     let gradients3D: Vec<_> = GRAD3_SRC
         .iter()
         .map(|v| (v / NORMALIZER_3D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_3D * 4) as usize)
         .collect();
@@ -852,8 +848,6 @@ fn initStaticData() -> StaticData {
     let gradients4D: Vec<_> = GRAD4_SRC
         .iter()
         .map(|v| (v / NORMALIZER_4D) as f32)
-        .collect::<Vec<_>>() // cache divisions
-        .into_iter()
         .cycle()
         .take((N_GRADS_4D * 4) as usize)
         .collect();


### PR DESCRIPTION
See: #28

Note: Merge After #29

**Description of Changes:**

    Added support for CMake projects.

    Added a CMake Interface library that collects data from the C and Rust implementations and makes it available to any C++/C projects.

**BackEnd Implementation Selection:**

The BackEnd implementation can be chosen using the following CMake options:

    option(OPENSIMPLEX_C "Enable building the legacy C implementation instead of Rust" ON)

    option(OPENSIMPLEX_RUST "Enable building the Rust implementation" ON)

**By default, only the Rust implementation is enabled.**